### PR TITLE
Implemented Stack Smashing Protector with hard-coded guard value GH-1

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -15,7 +15,7 @@ export BOOTDIR=/boot
 export LIBDIR=$EXEC_PREFIX/lib
 export INCLUDEDIR=$PREFIX/include
 
-export CFLAGS='-O2 -g'
+export CFLAGS='-O2 -g -fstack-protector-strong'
 export CPPFLAGS=''
 
 # Configure the cross-compiler to use the desired system root.

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -29,6 +29,7 @@ LIBK_CPPFLAGS:=$(LIBK_CPPFLAGS) $(KERNEL_ARCH_CPPFLAGS)
 
 FREEOBJS=\
 $(ARCH_FREEOBJS) \
+stdlib/stack_guard.o \
 stdio/printf.o \
 stdio/putchar.o \
 stdio/puts.o \

--- a/libc/include/bits/types.h
+++ b/libc/include/bits/types.h
@@ -1,0 +1,217 @@
+#ifndef _INTERNAL_TYPES_H
+#define _INTERNAL_TYPES_H
+
+typedef __UINT8_TYPE__ __uint8;
+typedef __UINT16_TYPE__ __uint16;
+typedef __UINT32_TYPE__ __uint32;
+typedef __UINT64_TYPE__ __uint64;
+
+typedef __INT8_TYPE__ __int8;
+typedef __INT16_TYPE__ __int16;
+typedef __INT32_TYPE__ __int32;
+typedef __INT64_TYPE__ __int64;
+
+
+#define __INT8_C(x)  __INT8_C(x)
+#define __INT16_C(x) __INT16_C(x)
+#define __INT32_C(x) __INT32_C(x)
+#define __INT64_C(x) __INT64_C(x)
+
+#define __UINT8_C(x)  __UINT8_C(x)
+#define __UINT16_C(x) __UINT16_C(x)
+#define __UINT32_C(x) __UINT32_C(x)
+#define __UINT64_C(x) __UINT64_C(x)
+
+#define __INTMAX_C(x) __INTMAX_C(x)
+#define __UINTMAX_C(x) __UINTMAX_C(x)
+
+#define __INT8_MAX  __INT8_MAX__
+#define __INT16_MAX __INT16_MAX__
+#define __INT32_MAX __INT32_MAX__
+#define __INT64_MAX __INT64_MAX__
+
+#define __INT8_MIN  (-__INT8_MAX - 1)
+#define __INT16_MIN (-__INT16_MAX - 1)
+#define __INT32_MIN (-__INT32_MAX - 1)
+#define __INT64_MIN (-__INT64_MAX - 1)
+
+#define __UINT8_MAX  __UINT8_MAX__
+#define __UINT16_MAX __UINT16_MAX__
+#define __UINT32_MAX __UINT32_MAX__
+#define __UINT64_MAX __UINT64_MAX__
+
+// Fast types (signed).
+
+#if defined (__i386__)
+
+typedef __int8 __int_fast8;
+#define __INT_FAST8_C(x) __INT8_C(x)
+#define __INT_FAST8_MAX __INT8_MAX
+#define __INT_FAST8_MIN __INT8_MIN
+
+typedef __int32 __int_fast16;
+#define __INT_FAST16_C(x) __INT32_C(x)
+#define __INT_FAST16_MAX __INT32_MAX
+#define __INT_FAST16_MIN __INT32_MIN
+
+typedef __int32 __int_fast32;
+#define __INT_FAST32_C(x) __INT32_C(x)
+#define __INT_FAST32_MAX __INT32_MAX
+#define __INT_FAST32_MIN __INT32_MIN
+
+typedef __int64 __int_fast64;
+#define __INT_FAST64_C(x) __INT64_C(x)
+#define __INT_FAST64_MAX __INT64_MAX
+#define __INT_FAST64_MIN __INT64_MIN
+
+#elif defined (__x86_64__)
+
+typedef __int8 __int_fast8;
+#define __INT_FAST8_C(x) __INT8_C(x)
+#define __INT_FAST8_MAX __INT8_MAX
+#define __INT_FAST8_MIN __INT8_MIN
+
+typedef __int64 __int_fast16;
+#define __INT_FAST16_C(x) __INT64_C(x)
+#define __INT_FAST16_MAX __INT64_MAX
+#define __INT_FAST16_MIN __INT64_MIN
+
+typedef __int64 __int_fast32;
+#define __INT_FAST32_C(x) __INT64_C(x)
+#define __INT_FAST32_MAX __INT64_MAX
+#define __INT_FAST32_MIN __INT64_MIN
+
+typedef __int64 __int_fast64;
+#define __INT_FAST64_C(x) __INT64_C(x)
+#define __INT_FAST64_MAX __INT64_MAX
+#define __INT_FAST64_MIN __INT64_MIN
+
+#elif defined (__aarch64__)
+
+typedef __int8 __int_fast8;
+#define __INT_FAST8_C(x) __INT8_C(x)
+#define __INT_FAST8_MAX __INT8_MAX
+#define __INT_FAST8_MIN __INT8_MIN
+
+typedef __int64 __int_fast16;
+#define __INT_FAST16_C(x) __INT64_C(x)
+#define __INT_FAST16_MAX __INT64_MAX
+#define __INT_FAST16_MIN __INT64_MIN
+
+typedef __int64 __int_fast32;
+#define __INT_FAST32_C(x) __INT64_C(x)
+#define __INT_FAST32_MAX __INT64_MAX
+#define __INT_FAST32_MIN __INT64_MIN
+
+typedef __int64 __int_fast64;
+#define __INT_FAST64_C(x) __INT64_C(x)
+#define __INT_FAST64_MAX __INT64_MAX
+#define __INT_FAST64_MIN __INT64_MIN
+
+#else
+#  error "Missing architecture specific code"
+#endif
+
+// Fast types (unsigned).
+
+#if defined (__i386__)
+
+typedef __uint8 __uint_fast8;
+#define __UINT_FAST8_C(x) __UINT8_C(x)
+#define __UINT_FAST8_MAX __UINT8_MAX
+#define __UINT_FAST8_MIN __UINT8_MIN
+
+typedef __uint32 __uint_fast16;
+#define __UINT_FAST16_C(x) __UINT32_C(x)
+#define __UINT_FAST16_MAX __UINT32_MAX
+#define __UINT_FAST16_MIN __UINT32_MIN
+
+typedef __uint32 __uint_fast32;
+#define __UINT_FAST32_C(x) __UINT32_C(x)
+#define __UINT_FAST32_MAX __UINT32_MAX
+#define __UINT_FAST32_MIN __UINT32_MIN
+
+typedef __uint64 __uint_fast64;
+#define __UINT_FAST64_C(x) __UINT64_C(x)
+#define __UINT_FAST64_MAX __UINT64_MAX
+#define __UINT_FAST64_MIN __UINT64_MIN
+
+#elif defined (__x86_64__)
+
+typedef __uint8 __uint_fast8;
+#define __UINT_FAST8_C(x) __UINT8_C(x)
+#define __UINT_FAST8_MAX __UINT8_MAX
+#define __UINT_FAST8_MIN __UINT8_MIN
+
+typedef __uint64 __uint_fast16;
+#define __UINT_FAST16_C(x) __UINT64_C(x)
+#define __UINT_FAST16_MAX __UINT64_MAX
+#define __UINT_FAST16_MIN __UINT64_MIN
+
+typedef __uint64 __uint_fast32;
+#define __UINT_FAST32_C(x) __UINT64_C(x)
+#define __UINT_FAST32_MAX __UINT64_MAX
+#define __UINT_FAST32_MIN __UINT64_MIN
+
+typedef __uint64 __uint_fast64;
+#define __UINT_FAST64_C(x) __UINT64_C(x)
+#define __UINT_FAST64_MAX __UINT64_MAX
+#define __UINT_FAST64_MIN __UINT64_MIN
+
+#elif defined (__aarch64__)
+
+typedef __uint8 __uint_fast8;
+#define __UINT_FAST8_C(x) __UINT8_C(x)
+#define __UINT_FAST8_MAX __UINT8_MAX
+#define __UINT_FAST8_MIN __UINT8_MIN
+
+typedef __uint64 __uint_fast16;
+#define __UINT_FAST16_C(x) __UINT64_C(x)
+#define __UINT_FAST16_MAX __UINT64_MAX
+#define __UINT_FAST16_MIN __UINT64_MIN
+
+typedef __uint64 __uint_fast32;
+#define __UINT_FAST32_C(x) __UINT64_C(x)
+#define __UINT_FAST32_MAX __UINT64_MAX
+#define __UINT_FAST32_MIN __UINT64_MIN
+
+typedef __uint64 __uint_fast64;
+#define __UINT_FAST64_C(x) __UINT64_C(x)
+#define __UINT_FAST64_MAX __UINT64_MAX
+#define __UINT_FAST64_MIN __UINT64_MIN
+
+#else
+#  error "Missing architecture specific code"
+#endif
+
+// Special types.
+
+typedef __INTMAX_TYPE__ __intmax;
+typedef __INTPTR_TYPE__ __intptr;
+typedef __PTRDIFF_TYPE__ __ptrdiff;
+#define __INTMAX_MAX __INTMAX_MAX__
+#define __INTMAX_MIN (-__INTMAX_MAX__ - 1)
+#define __INTPTR_MAX __INTPTR_MAX__
+#define __INTPTR_MIN (-__INTPTR_MAX__ - 1)
+#define __PTRDIFF_MAX __PTRDIFF_MAX__
+#define __PTRDIFF_MIN (-__PTRDIFF_MAX__ - 1)
+
+typedef __UINTMAX_TYPE__ __uintmax;
+typedef __UINTPTR_TYPE__ __uintptr;
+typedef __SIZE_TYPE__ __size;
+#define __UINTMAX_MAX __UINTMAX_MAX__
+#define __UINTPTR_MAX __UINTPTR_MAX__
+#define __SIZE_MAX __SIZE_MAX__
+
+// Other limits.
+
+#define __WCHAR_MAX __WCHAR_MAX__
+#define __WCHAR_MIN __WCHAR_MIN__
+
+#define __WINT_MAX __WINT_MAX__
+#define __WINT_MIN __WINT_MIN__
+
+#define __SIG_ATOMIC_MAX __SIG_ATOMIC_MAX__
+#define __SIG_ATOMIC_MIN __SIG_ATOMIC_MIN__
+
+#endif // _INTERNAL_TYPES_H

--- a/libc/include/bits/wchar.h
+++ b/libc/include/bits/wchar.h
@@ -1,0 +1,9 @@
+#ifndef WCHAR_H
+#define WCHAR_H
+
+#include <bits/types.h>
+
+#define WCHAR_MAX      _WCHAR_MAX
+#define WCHAR_MIN      _WCHAR_MIN
+
+#endif // WCHAR_H

--- a/libc/include/stdint.h
+++ b/libc/include/stdint.h
@@ -1,0 +1,150 @@
+#ifndef _STDINT_H
+#define _STDINT_H
+
+#include <bits/types.h>
+#include <bits/wchar.h>
+
+// ----------------------------------------------------------------------------
+// Type definitions.
+// ----------------------------------------------------------------------------
+
+// Fixed-width (signed).
+typedef __int8  int8_t;
+typedef __int16 int16_t;
+typedef __int32 int32_t;
+typedef __int64 int64_t;
+
+// Fixed-width (unsigned).
+typedef __uint8  uint8_t;
+typedef __uint16 uint16_t;
+typedef __uint32 uint32_t;
+typedef __uint64 uint64_t;
+
+// Least-width (signed).
+typedef __int8  int_least8_t;
+typedef __int16 int_least16_t;
+typedef __int32 int_least32_t;
+typedef __int64 int_least64_t;
+
+// Least-width (unsigned).
+typedef __uint8  uint_least8_t;
+typedef __uint16 uint_least16_t;
+typedef __uint32 uint_least32_t;
+typedef __uint64 uint_least64_t;
+
+// Fast-width (signed).
+typedef __int_fast8  int_fast8_t;
+typedef __int_fast16 int_fast16_t;
+typedef __int_fast32 int_fast32_t;
+typedef __int_fast64 int_fast64_t;
+
+// Fast-width (unsigned).
+typedef __uint_fast8  uint_fast8_t;
+typedef __uint_fast16 uint_fast16_t;
+typedef __uint_fast32 uint_fast32_t;
+typedef __uint_fast64 uint_fast64_t;
+
+// Miscellaneous (signed).
+typedef __intmax intmax_t;
+typedef __intptr intptr_t;
+
+// Miscellaneous (unsigned).
+typedef __uintmax uintmax_t;
+typedef __uintptr uintptr_t;
+
+// ----------------------------------------------------------------------------
+// Constants.
+// ----------------------------------------------------------------------------
+
+// Fixed-width (signed).
+#define INT8_C(x)  __INT8_C(x)
+#define INT16_C(x) __INT16_C(x)
+#define INT32_C(x) __INT32_C(x)
+#define INT64_C(x) __INT64_C(x)
+#define INTMAX_C(x) __INTMAX_C(x)
+
+// Fixed-width (unsigned).
+#define UINT8_C(x)  __UINT8_C(x)
+#define UINT16_C(x) __UINT16_C(x)
+#define UINT32_C(x) __UINT32_C(x)
+#define UINT64_C(x) __UINT64_C(x)
+#define UINTMAX_C(x) __UINTMAX_C(x)
+
+// ----------------------------------------------------------------------------
+// Limits.
+// ----------------------------------------------------------------------------
+
+// Fixed-width (signed).
+#define INT8_MAX  __INT8_MAX
+#define INT16_MAX __INT16_MAX
+#define INT32_MAX __INT32_MAX
+#define INT64_MAX __INT64_MAX
+
+#define INT8_MIN  __INT8_MIN
+#define INT16_MIN __INT16_MIN
+#define INT32_MIN __INT32_MIN
+#define INT64_MIN __INT64_MIN
+
+// Fixed-width (unsigned).
+#define UINT8_MAX  __UINT8_MAX
+#define UINT16_MAX __UINT16_MAX
+#define UINT32_MAX __UINT32_MAX
+#define UINT64_MAX __UINT64_MAX
+
+// Least-width (signed).
+#define INT_LEAST8_MAX  __INT8_MAX
+#define INT_LEAST16_MAX __INT16_MAX
+#define INT_LEAST32_MAX __INT32_MAX
+#define INT_LEAST64_MAX __INT64_MAX
+
+#define INT_LEAST8_MIN  __INT8_MIN
+#define INT_LEAST16_MIN __INT16_MIN
+#define INT_LEAST32_MIN __INT32_MIN
+#define INT_LEAST64_MIN __INT64_MIN
+
+// Least-width (unsigned).
+#define UINT_LEAST8_MAX  __UINT8_MAX
+#define UINT_LEAST16_MAX __UINT16_MAX
+#define UINT_LEAST32_MAX __UINT32_MAX
+#define UINT_LEAST64_MAX __UINT64_MAX
+
+// Fast-width (signed).
+#define INT_FAST8_MAX  __INT_FAST8_MAX
+#define INT_FAST16_MAX __INT_FAST16_MAX
+#define INT_FAST32_MAX __INT_FAST32_MAX
+#define INT_FAST64_MAX __INT_FAST64_MAX
+
+#define INT_FAST8_MIN  __INT_FAST8_MIN
+#define INT_FAST16_MIN __INT_FAST16_MIN
+#define INT_FAST32_MIN __INT_FAST32_MIN
+#define INT_FAST64_MIN __INT_FAST64_MIN
+
+// Fast-width (unsigned).
+#define UINT_FAST8_MAX  __UINT_FAST8_MAX
+#define UINT_FAST16_MAX __UINT_FAST16_MAX
+#define UINT_FAST32_MAX __UINT_FAST32_MAX
+#define UINT_FAST64_MAX __UINT_FAST64_MAX
+
+// Miscellaneous (signed).
+#define INTMAX_MAX __INTMAX_MAX
+#define INTPTR_MAX __INTPTR_MAX
+
+#define INTMAX_MIN __INTMAX_MIN
+#define INTPTR_MIN __INTPTR_MIN
+
+// Miscellaneous (unsigned).
+#define UINTMAX_MAX __UINTMAX_MAX
+#define UINTPTR_MAX __UINTPTR_MAX
+
+// Other limits (signed).
+#define PTRDIFF_MAX    __PTRDIFF_MAX
+#define PTRDIFF_MIN    __PTRDIFF_MIN
+#define SIG_ATOMIC_MAX __SIG_ATOMIC_MAX
+#define SIG_ATOMIC_MIN __SIG_ATOMIC_MIN
+#define WINT_MAX       __WINT_MAX
+#define WINT_MIN       __WINT_MIN
+
+// Other limits (unsigned).
+#define SIZE_MAX __SIZE_MAX
+
+#endif // _STDINT_H

--- a/libc/stdlib/stack_guard.c
+++ b/libc/stdlib/stack_guard.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#if UINT32_MAX == UINTPTR_MAX
+#define STACK_CHK_GUARD 0xe2dee396
+#else
+#define STACK_CHK_GUARD 0x595e9fbd94fda766
+#endif
+
+uintptr_t __stack_chk_guard = STACK_CHK_GUARD;
+
+__attribute__((noreturn))
+void __stack_chk_fail(void)
+{
+#if __STDC_HOSTED__
+    abort();
+#elif __is_redos_kernel
+    panic("Stack smashing detected");
+#endif
+}


### PR DESCRIPTION
# Added
- LibC basic types header
- LibC wchar header
- LibC stdint header
- Stack Smash Protector as stack guard with hard-coded guard value

# Changed
- Kernel and LibC now by default compile with -fstack-protector-strong for now

Closes #1 