### PR TITLE
Implemented printf formatting for basic placeholders. Added kernel TTY support for \n and \t GH-4

### DIFF
--- a/kernel/arch/i386/tty.c
+++ b/kernel/arch/i386/tty.c
@@ -9,50 +9,66 @@
 
 static const size_t VGA_WIDTH = 80;
 static const size_t VGA_HEIGHT = 25;
-static uint16_t* const VGA_MEMORY = (uint16_t*) 0xB8000;
+static uint16_t *const VGA_MEMORY = (uint16_t *) 0xB8000;
 
 static size_t terminal_row;
 static size_t terminal_column;
 static uint8_t terminal_color;
-static uint16_t* terminal_buffer;
+static uint16_t *terminal_buffer;
 
 void terminal_initialize(void) {
-	terminal_row = 0;
-	terminal_column = 0;
-	terminal_color = vga_entry_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
-	terminal_buffer = VGA_MEMORY;
-	for (size_t y = 0; y < VGA_HEIGHT; y++) {
-		for (size_t x = 0; x < VGA_WIDTH; x++) {
-			const size_t index = y * VGA_WIDTH + x;
-			terminal_buffer[index] = vga_entry(' ', terminal_color);
-		}
-	}
+    terminal_row = 0;
+    terminal_column = 0;
+    terminal_color = vga_entry_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+    terminal_buffer = VGA_MEMORY;
+    for (size_t y = 0; y < VGA_HEIGHT; y++) {
+        for (size_t x = 0; x < VGA_WIDTH; x++) {
+            const size_t index = y * VGA_WIDTH + x;
+            terminal_buffer[index] = vga_entry(' ', terminal_color);
+        }
+    }
 }
 
 void terminal_setcolor(uint8_t color) {
-	terminal_color = color;
+    terminal_color = color;
 }
 
 void terminal_putentryat(unsigned char c, uint8_t color, size_t x, size_t y) {
-	const size_t index = y * VGA_WIDTH + x;
-	terminal_buffer[index] = vga_entry(c, color);
+    const size_t index = y * VGA_WIDTH + x;
+    terminal_buffer[index] = vga_entry(c, color);
 }
 
 void terminal_putchar(char c) {
-	unsigned char uc = c;
-	terminal_putentryat(uc, terminal_color, terminal_column, terminal_row);
-	if (++terminal_column == VGA_WIDTH) {
-		terminal_column = 0;
-		if (++terminal_row == VGA_HEIGHT)
-			terminal_row = 0;
-	}
+    unsigned char uc = c;
+    if (c == '\n') {
+        terminal_column = 0;
+        if (++terminal_row == VGA_HEIGHT)
+            terminal_row = 0;
+        return;
+    }
+    if (c == '\t') {
+        terminal_column += 4;
+        if (terminal_column == VGA_WIDTH) {
+            terminal_column = 0;
+            if (++terminal_row == VGA_HEIGHT)
+                terminal_row = 0;
+        }
+        return;
+    }
+    terminal_putentryat(uc, terminal_color, terminal_column, terminal_row);
+
+    if (++terminal_column == VGA_WIDTH) {
+        terminal_column = 0;
+        if (++terminal_row == VGA_HEIGHT)
+            terminal_row = 0;
+    }
 }
 
-void terminal_write(const char* data, size_t size) {
-	for (size_t i = 0; i < size; i++)
-		terminal_putchar(data[i]);
+void terminal_write(const char *data, size_t size) {
+    for (size_t i = 0; i < size; i++)
+        terminal_putchar(data[i]);
 }
 
-void terminal_writestring(const char* data) {
-	terminal_write(data, strlen(data));
+void terminal_writestring(const char *data) {
+    terminal_write(data, strlen(data));
 }

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -5,4 +5,14 @@
 void kernel_main(void) {
 	terminal_initialize();
 	printf("Terminal Initialized Successfully!\n");
+    printf("Character: %c %c \n", 'r', 80);
+    printf("String: %s \n", "I am test string");
+    printf("Decimal: %d %d %d \n", 540 + 4242, -231, 0);
+    printf("Hexadecimal: %x %x %x \n", 550, 0, -550);
+    printf("Octal: %o %o %o \n", 550, 0, -550);
+    printf("Float: %f %f %f %f %f \n", -123.456, 123.456, (double) 0, 0.123, -0.456);
+
+    int a = 51;
+
+    printf("Pointer: %p \n", &a);
 }

--- a/libc/stdio/printf.c
+++ b/libc/stdio/printf.c
@@ -4,77 +4,253 @@
 #include <stdio.h>
 #include <string.h>
 
-static bool print(const char* data, size_t length) {
-	const unsigned char* bytes = (const unsigned char*) data;
-	for (size_t i = 0; i < length; i++)
-		if (putchar(bytes[i]) == EOF)
-			return false;
-	return true;
+static bool print(const char *data, size_t length) {
+    const unsigned char *bytes = (const unsigned char *) data;
+    for (size_t i = 0; i < length; i++)
+        if (putchar(bytes[i]) == EOF)
+            return false;
+    return true;
 }
 
-int printf(const char* restrict format, ...) {
-	va_list parameters;
-	va_start(parameters, format);
+//TODO: Rewrite that monster and add support for all C-standard fomatting options and implement it in vprintf
+int printf(const char *restrict format, ...) {
+    va_list parameters;
+    va_start(parameters, format);
 
-	int written = 0;
+    int written = 0;
 
-	while (*format != '\0') {
-		size_t maxrem = INT_MAX - written;
+    while (*format != '\0') {
+        size_t maxrem = INT_MAX - written;
 
-		if (format[0] != '%' || format[1] == '%') {
-			if (format[0] == '%')
-				format++;
-			size_t amount = 1;
-			while (format[amount] && format[amount] != '%')
-				amount++;
-			if (maxrem < amount) {
-				// TODO: Set errno to EOVERFLOW.
-				return -1;
-			}
-			if (!print(format, amount))
-				return -1;
-			format += amount;
-			written += amount;
-			continue;
-		}
+        if (format[0] != '%' || format[1] == '%') {
+            if (format[0] == '%')
+                format++;
+            size_t amount = 1;
+            while (format[amount] && format[amount] != '%')
+                amount++;
+            if (maxrem < amount) {
+                // TODO: Set errno to EOVERFLOW.
+                return -1;
+            }
+            if (!print(format, amount))
+                return -1;
+            format += amount;
+            written += amount;
+            continue;
+        }
 
-		const char* format_begun_at = format++;
+        const char *format_begun_at = format++;
 
-		if (*format == 'c') {
-			format++;
-			char c = (char) va_arg(parameters, int /* char promotes to int */);
-			if (!maxrem) {
-				// TODO: Set errno to EOVERFLOW.
-				return -1;
-			}
-			if (!print(&c, sizeof(c)))
-				return -1;
-			written++;
-		} else if (*format == 's') {
-			format++;
-			const char* str = va_arg(parameters, const char*);
-			size_t len = strlen(str);
-			if (maxrem < len) {
-				// TODO: Set errno to EOVERFLOW.
-				return -1;
-			}
-			if (!print(str, len))
-				return -1;
-			written += len;
-		} else {
-			format = format_begun_at;
-			size_t len = strlen(format);
-			if (maxrem < len) {
-				// TODO: Set errno to EOVERFLOW.
-				return -1;
-			}
-			if (!print(format, len))
-				return -1;
-			written += len;
-			format += len;
-		}
-	}
+        const char zero = '0';
+        const char minus = '-';
 
-	va_end(parameters);
-	return written;
+        if (*format == 'c') {
+            format++;
+            char c = (char) va_arg(parameters, int /* char promotes to int */);
+            if (!maxrem) {
+                // TODO: Set errno to EOVERFLOW.
+                return -1;
+            }
+            if (!print(&c, sizeof(c)))
+                return -1;
+            written++;
+        } else if (*format == 's') {
+            format++;
+            const char *str = va_arg(parameters, const char*);
+            size_t len = strlen(str);
+            if (maxrem < len) {
+                // TODO: Set errno to EOVERFLOW.
+                return -1;
+            }
+            if (!print(str, len))
+                return -1;
+            written += len;
+        } else if (*format == 'd') {
+            format++;
+            int num = va_arg(parameters, int);
+            int i = 0, sign = 1;
+            if (num == 0) {
+                written++;
+                putchar(zero);
+            }
+            if (num < 0) {
+                sign = -1;
+                num = -num;
+            }
+
+            char arr[32];
+
+            while (num > 0) {
+                arr[i++] = (num % 10) + '0';
+                num /= 10;
+                written++;
+            }
+            if (sign == -1) {
+                written++;
+                putchar(minus);
+            }
+            while (i > 0) {
+                written++;
+                putchar(arr[--i]);
+            }
+        } else if (*format == 'x') {
+            format++;
+            int num = va_arg(parameters, int);
+            int i = 0, sign = 1;
+            const char *hexademical_zero = "0x0";
+            char arr[32];
+            if (num == 0) {
+                written += 3;
+                if (!print(hexademical_zero, sizeof(hexademical_zero)))
+                    return -1;
+            } else {
+                if (num < 0) {
+                    sign = -1;
+                    num = -num;
+                }
+                while (num > 0) {
+                    int rem = num % 16;
+                    if (rem < 10) {
+                        arr[i++] = rem + '0';
+                    } else {
+                        arr[i++] = rem - 10 + 'A';
+                    }
+                    num /= 16;
+                }
+                if (sign == -1) {
+                    written++;
+                    putchar('-');
+                }
+                putchar('0');
+                putchar('x');
+
+                written += 2;
+                while (i > 0) {
+                    written++;
+                    putchar(arr[--i]);
+                }
+            }
+        } else if (*format == 'o') {
+            format++;
+            int num = va_arg(parameters, int);
+            int i = 0, sign = 1;
+            char arr[32];
+            if (num == 0) {
+                written++;
+                putchar(zero);
+            } else {
+                if (num < 0) {
+                    sign = -1;
+                    num = -num;
+                }
+                while (num > 0) {
+                    int rem = num % 8;
+                    arr[i++] = rem + '0';
+                    num /= 8;
+                }
+                if (sign == -1) {
+                    written++;
+                    putchar('-');
+                }
+                putchar('0');
+
+                written++;
+                while (i > 0) {
+                    written++;
+                    putchar(arr[--i]);
+                }
+            }
+        } else if (*format == 'f') {
+            format++;
+            double num = va_arg(parameters, double);
+            int sign = (num < 0) ? -1 : 1;
+            num *= sign;
+            int int_part = (int) num;
+            double dec_part = num - int_part;
+            int i = 0;
+            char arr[32];
+            if (sign == -1) {
+                written++;
+                putchar('-');
+            }
+            if (int_part == 0) {
+                written++;
+                putchar('0');
+            }
+            while (int_part > 0) {
+                int rem = int_part % 10;
+                arr[i++] = rem + '0';
+                int_part /= 10;
+            }
+            while (i > 0) {
+                written++;
+                putchar(arr[--i]);
+            }
+            if (dec_part > 0) {
+                putchar('.');
+                written++;
+                i = 0;
+                while (dec_part > 0 && i < 5) {
+                    dec_part *= 10;
+                    int d = (int) dec_part;
+                    arr[i++] = d + '0';
+                    dec_part -= d;
+                }
+                i = 0;
+                while (i < 5) {
+                    written++;
+                    putchar(arr[i]);
+                    arr[i++] = 0;
+                }
+            }
+        } else if (*format == 'p') {
+            format++;
+            void *pointer = va_arg(parameters, void*);
+
+            const char *nil = "nil";
+            if (pointer == NULL) {
+                written += 3;
+                if (!print(nil, sizeof(nil)))
+                    return -1;
+            } else {
+                unsigned long int num = (unsigned long int) pointer;
+                int i = 0;
+                const char *hexademical_zero = "0x0";
+                char arr[32];
+
+                while (num > 0) {
+                    int rem = num % 16;
+                    if (rem < 10) {
+                        arr[i++] = rem + '0';
+                    } else {
+                        arr[i++] = rem - 10 + 'A';
+                    }
+                    num /= 16;
+                }
+
+                putchar('0');
+                putchar('x');
+
+                written += 2;
+                while (i > 0) {
+                    written++;
+                    putchar(arr[--i]);
+                }
+            }
+        } else {
+            format = format_begun_at;
+            size_t len = strlen(format);
+            if (maxrem < len) {
+                // TODO: Set errno to EOVERFLOW.
+                return -1;
+            }
+            if (!print(format, len))
+                return -1;
+            written += len;
+            format += len;
+        }
+    }
+
+    va_end(parameters);
+    return written;
 }


### PR DESCRIPTION
# Added
- Printf support for decimal numbers via %d option
- Printf support for float numbers via %f option
- Printf support for hexadecimal numbers via %x option
- Printf support for octal numbers via %o option
- Printf support for pointers via %p option
- Kernel TTY support for \n and \t special symbols